### PR TITLE
docs: add Tailor SDK link and restore BSR link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ This repository contains the Protocol Buffer definitions for the Tailor Platform
 
 The [`tailor/**`](https://github.com/tailor-inc/proto/tree/main/tailor/) definitions in this repository represent the **controlplane RPCs** used to manage and configure the Tailor Platform resources.
 
-These APIs are designed to be used with various tools and services. You can also use these definitions to generate client libraries in different programming languages.
+These APIs are designed to be used with various tools and services. You can also use these definitions to generate client libraries in different programming languages. The definitions are also available on the [Buf Schema Registry (BSR)](https://buf.build/tailor-inc/tailor).
 
 Below are officially supported Client Libraries for the Tailor Platform:
 
+- **[Tailor SDK](https://github.com/tailor-platform/sdk/)**: TypeScript SDK for building and managing Tailor Platform applications
 - **[tailorctl](https://github.com/tailor-platform/tailorctl)**: Command-line interface for application development and deployment
 - **[Tailor Platform Terraform Provider](https://github.com/tailor-platform/terraform-provider-tailor)**: Infrastructure as Code (IaC) provider for managing Tailor resources
 


### PR DESCRIPTION
## Summary

- Add **[Tailor SDK](https://github.com/tailor-platform/sdk/)** to the top of the supported client libraries list in the README
- Restore the **[Buf Schema Registry (BSR)](https://buf.build/tailor-inc/tailor)** link originally added in fdc5203 (#3), which was unintentionally reverted by the automated proto sync (ddd379f)

## Note

Since `tailor-releaser` syncs the README from an upstream source, these changes should also be applied there — otherwise the next `update proto` run will revert them again, as happened with the BSR link.